### PR TITLE
Update README for API token instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,45 @@ This MCP server provides several tools that Claude can use:
    ```bash
    pip install -r requirements.txt
    ```
-2. Set the `WARPCAST_API_TOKEN` environment variable with your API token.
+2. Obtain a Warpcast API token and export it as an environment variable:
+   - Log in to [Warpcast](https://warpcast.com/) and open **Settings \> Developer**.
+   - Click **Create API Token** and copy the value.
+   - Set `WARPCAST_API_TOKEN` in your shell:
+     ```bash
+     export WARPCAST_API_TOKEN=YOUR_TOKEN
+     ```
 3. Start the server:
    ```bash
    uvicorn main:app --reload
    ```
 
 The server exposes HTTP endpoints matching the tools listed above.
+
+## Using with Claude Desktop
+
+Follow these steps to access the Warpcast tools from Claude's desktop application:
+
+1. Start the server (or let Claude launch it) using the setup instructions above.
+2. Open your Claude configuration file:
+   - **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+   - **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+3. Add the Warpcast server under the `mcpServers` key. Replace the path with the location of this repository:
+
+```json
+{
+  "mcpServers": {
+    "warpcast": {
+      "command": "uvicorn",
+      "args": [
+        "--app-dir",
+        "/ABSOLUTE/PATH/TO/mcp-warpcast-server",
+        "main:app",
+        "--port",
+        "8000"
+      ]
+    }
+  }
+}
+```
+
+4. Save the file and restart Claude Desktop. You should now see a hammer icon in the chat input that lets you use the Warpcast tools.


### PR DESCRIPTION
## Summary
- document how to obtain and set the Warpcast API token in the Setup section

## Testing
- `python -m py_compile main.py warpcast_api.py __init__.py`
