### PR TITLE
Validate API token on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ This MCP server provides several tools that Claude can use:
      ```bash
      export WARPCAST_API_TOKEN=YOUR_TOKEN
      ```
- You can either set the
-   `WARPCAST_API_TOKEN` environment variable or supply it in the `env`
-   section of Claude's configuration (see below).
+   The server validates this variable on startup. If it is missing, a warning
+   is logged and authorized requests will respond with **HTTP 500** errors.
+   You can either set the `WARPCAST_API_TOKEN` environment variable or supply it
+   in the `env` section of Claude's configuration (see below).
    
 3. Start the server:
    ```bash

--- a/main.py
+++ b/main.py
@@ -1,9 +1,27 @@
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
-
+import logging
 import warpcast_api
 
+logger = logging.getLogger(__name__)
+
 app = FastAPI(title="Warpcast MCP Server")
+
+
+@app.on_event("startup")
+async def validate_token() -> None:
+    if not warpcast_api.has_token():
+        logger.warning(
+            "WARPCAST_API_TOKEN is not set. Requests requiring authorization will fail"
+        )
+
+
+def ensure_token() -> None:
+    if not warpcast_api.has_token():
+        raise HTTPException(
+            status_code=500,
+            detail="Server misconfigured: WARPCAST_API_TOKEN not set",
+        )
 
 
 class CastRequest(BaseModel):
@@ -16,6 +34,7 @@ class ChannelRequest(BaseModel):
 
 @app.post("/post-cast")
 def post_cast(req: CastRequest):
+    ensure_token()
     result = warpcast_api.post_cast(req.text)
     if result.get("status") == "error":
         raise HTTPException(status_code=400, detail=result["message"])
@@ -24,36 +43,43 @@ def post_cast(req: CastRequest):
 
 @app.get("/user-casts/{username}")
 def user_casts(username: str, limit: int = 20):
+    ensure_token()
     return warpcast_api.get_user_casts(username, limit)
 
 
 @app.get("/search-casts")
 def search_casts(q: str, limit: int = 20):
+    ensure_token()
     return warpcast_api.search_casts(q, limit)
 
 
 @app.get("/trending-casts")
 def trending_casts(limit: int = 20):
+    ensure_token()
     return warpcast_api.get_trending_casts(limit)
 
 
 @app.get("/channels")
 def all_channels():
+    ensure_token()
     return warpcast_api.get_all_channels()
 
 
 @app.get("/channels/{channel_id}")
 def get_channel(channel_id: str):
+    ensure_token()
     return warpcast_api.get_channel(channel_id)
 
 
 @app.get("/channels/{channel_id}/casts")
 def channel_casts(channel_id: str, limit: int = 20):
+    ensure_token()
     return warpcast_api.get_channel_casts(channel_id, limit)
 
 
 @app.post("/follow-channel")
 def follow_channel(req: ChannelRequest):
+    ensure_token()
     result = warpcast_api.follow_channel(req.channel_id)
     if result.get("status") == "error":
         raise HTTPException(status_code=400, detail=result["message"])
@@ -62,6 +88,7 @@ def follow_channel(req: ChannelRequest):
 
 @app.post("/unfollow-channel")
 def unfollow_channel(req: ChannelRequest):
+    ensure_token()
     result = warpcast_api.unfollow_channel(req.channel_id)
     if result.get("status") == "error":
         raise HTTPException(status_code=400, detail=result["message"])

--- a/warpcast_api.py
+++ b/warpcast_api.py
@@ -7,6 +7,11 @@ API_BASE_URL = "https://api.warpcast.com/v2"
 API_TOKEN = os.getenv("WARPCAST_API_TOKEN")
 
 
+def has_token() -> bool:
+    """Return True if the API token is configured."""
+    return bool(API_TOKEN)
+
+
 def _auth_headers() -> Dict[str, str]:
     if not API_TOKEN:
         return {}


### PR DESCRIPTION
## Summary
- add check in `warpcast_api` for configured token
- validate `WARPCAST_API_TOKEN` during FastAPI startup
- reject authorized requests with HTTP 500 when token is missing
- document token validation in README

## Testing
- `python -m py_compile main.py warpcast_api.py`