### PR TITLE
Add MCP handshake via SSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,19 @@ This MCP server provides several tools that Claude can use:
 
 The server exposes HTTP endpoints matching the tools listed above.
 
+### MCP Endpoint
+
+An additional `/mcp` route implements the [Model Context Protocol](https://modelcontextprotocol.io/). To use it:
+
+1. Start the server as usual:
+   ```bash
+   uvicorn main:app --reload
+   ```
+2. Open a Server-Sent Events connection to `http://localhost:8000/mcp`.
+3. POST JSON-RPC messages (such as the `initialize` request) to the same path.
+
+After initialization clients can discover the Warpcast tools using the `tools/list` method.
+
 ## Using with Claude Desktop
 
 Follow these steps to access the Warpcast tools from Claude's desktop application:

--- a/main.py
+++ b/main.py
@@ -1,9 +1,55 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
+import asyncio
+import json
 
 import warpcast_api
 
 app = FastAPI(title="Warpcast MCP Server")
+
+# Simple in-memory queue for SSE communication
+mcp_queue: asyncio.Queue | None = None
+
+# Tool definitions exposed via MCP
+TOOLS = [
+    {
+        "name": "post-cast",
+        "description": "Create a new post on Warpcast (max 320 characters)",
+    },
+    {
+        "name": "get-user-casts",
+        "description": "Retrieve recent casts from a specific user",
+    },
+    {
+        "name": "search-casts",
+        "description": "Search for casts by keyword or phrase",
+    },
+    {
+        "name": "get-trending-casts",
+        "description": "Get the currently trending casts on Warpcast",
+    },
+    {
+        "name": "get-all-channels",
+        "description": "List available channels on Warpcast",
+    },
+    {
+        "name": "get-channel",
+        "description": "Get information about a specific channel",
+    },
+    {
+        "name": "get-channel-casts",
+        "description": "Get casts from a specific channel",
+    },
+    {
+        "name": "follow-channel",
+        "description": "Follow a channel",
+    },
+    {
+        "name": "unfollow-channel",
+        "description": "Unfollow a channel",
+    },
+]
 
 
 class CastRequest(BaseModel):
@@ -12,6 +58,62 @@ class CastRequest(BaseModel):
 
 class ChannelRequest(BaseModel):
     channel_id: str
+
+
+async def _event_generator(queue: asyncio.Queue):
+    """Yield server-sent events from the queue."""
+    try:
+        while True:
+            data = await queue.get()
+            yield f"data: {json.dumps(data)}\n\n"
+    finally:
+        # Connection closed
+        if mcp_queue is queue:
+            globals()["mcp_queue"] = None
+
+
+@app.get("/mcp")
+async def mcp_stream():
+    """Establish an SSE connection for MCP messages."""
+    global mcp_queue
+    queue = asyncio.Queue()
+    mcp_queue = queue
+    return StreamingResponse(_event_generator(queue), media_type="text/event-stream")
+
+
+@app.post("/mcp")
+async def mcp_message(request: Request):
+    """Handle JSON-RPC messages sent by the client."""
+    message = await request.json()
+
+    if message.get("method") == "initialize":
+        if not mcp_queue:
+            raise HTTPException(status_code=400, detail="MCP stream not established")
+
+        response = {
+            "jsonrpc": "2.0",
+            "id": message.get("id"),
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {"listChanged": False}},
+                "serverInfo": {"name": "Warpcast MCP Server", "version": "0.1.0"},
+            },
+        }
+        await mcp_queue.put(response)
+        return {"status": "ok"}
+
+    if message.get("method") == "tools/list":
+        if not mcp_queue:
+            raise HTTPException(status_code=400, detail="MCP stream not established")
+        response = {
+            "jsonrpc": "2.0",
+            "id": message.get("id"),
+            "result": {"tools": TOOLS, "nextCursor": None},
+        }
+        await mcp_queue.put(response)
+        return {"status": "ok"}
+
+    raise HTTPException(status_code=404, detail="Method not found")
 
 
 @app.post("/post-cast")


### PR DESCRIPTION
## Summary
- support Model Context Protocol via `/mcp` SSE endpoint
- register warpcast tools so `tools/list` works
- document how to run the MCP-enabled server

## Testing
- `python -m py_compile main.py warpcast_api.py`