### PR TITLE
Remove unused handshake route

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,26 +126,29 @@ The tests mock the Warpcast API layer so no network connection is required.
 ## MCP Compatibility
 
 This server is compatible with the [Model Context Protocol](https://modelcontextprotocol.org/).
-MCP clients must perform a handshake before using any tools. The handshake
-confirms the protocol version and lets the client discover available endpoints.
+After opening a Server-Sent Events connection to `/mcp`, send an `initialize`
+JSON-RPC message. The response on the event stream includes
+`{"protocolVersion": "2024-11-05"}` which confirms compatibility.
 
-### Handshake example
+### Initialization example
 
-Start the server and issue a `POST` request to `/handshake`:
+In one terminal start listening for events:
 
 ```bash
-curl -X POST http://localhost:8000/handshake \
+curl -N http://localhost:8000/mcp
+```
+
+In another terminal send the `initialize` message:
+
+```bash
+curl -X POST http://localhost:8000/mcp \
      -H "Content-Type: application/json" \
-     -d '{"client": "curl", "protocol_version": "0.1"}'
+     -d '{"jsonrpc":"2.0","id":1,"method":"initialize"}'
 ```
 
-The server will respond with its protocol version:
+The server responds on the first terminal with the protocol version.
 
-```json
-{"server":"warpcast-mcp-server","protocol_version":"0.1"}
-```
-
-After the handshake you can call tool endpoints, for example to post a cast:
+After initialization you can call tool endpoints, for example to post a cast:
 
 ```bash
 curl -X POST http://localhost:8000/post-cast \

--- a/main.py
+++ b/main.py
@@ -136,19 +136,6 @@ async def mcp_message(request: Request):
 
     raise HTTPException(status_code=404, detail="Method not found")
     
-class HandshakeRequest(BaseModel):
-    """Payload for MCP handshake."""
-    client: Optional[str] = None
-    protocol_version: str = "0.1"
-
-
-@app.post("/handshake")
-def handshake(req: HandshakeRequest):
-    """Basic MCP handshake endpoint."""
-    return {
-        "server": "warpcast-mcp-server",
-        "protocol_version": req.protocol_version,
-    }
 
 @app.post("/post-cast")
 def post_cast(req: CastRequest):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -96,3 +96,8 @@ def test_unfollow_channel(monkeypatch):
     assert response.status_code == 200
     assert response.json() == {"status": "success", "channel": "xyz"}
 
+
+def test_handshake_removed():
+    response = client.post("/handshake", json={})
+    assert response.status_code == 404
+


### PR DESCRIPTION
## Summary
- remove obsolete `/handshake` endpoint
- clarify MCP initialization steps in README
- add regression test checking `/handshake` is gone

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement requests)*
- `pytest -q` *(fails: command not found)*