### PR TITLE
Fix indentation in requests stub

### DIFF
--- a/requests.py
+++ b/requests.py
@@ -1,39 +1,45 @@
+"""Minimal stub of the ``requests`` module used during testing.
+
+This file provides a small subset of the real ``requests`` API so that the
+application code can be imported without pulling in the actual dependency or
+performing network calls.  Each HTTP method simply raises ``NotImplementedError``
+so tests can monkeypatch the functions as needed.
+"""
+
+
+class RequestException(Exception):
+    """Exception mimicking ``requests.RequestException``."""
+
+
 class Response:
-    def __init__(self, json_data=None, status_code=200):
-        self._json = json_data
-        self.status_code = status_code
-    def json(self):
-        return self._json
-    def raise_for_status(self):
-        if self.status_code >= 400:
-            raise Exception('HTTP error')
+    """Simple container for JSON data returned by mocked requests."""
 
-def get(*args, **kwargs):
-    raise RuntimeError('requests.get called in stub')
-
-def post(*args, **kwargs):
-    raise RuntimeError('requests.post called in stub')
+    def __init__(self, json_data=None, status_code: int = 200) -> None:
         self._json = json_data or {}
         self.status_code = status_code
 
     def json(self):
         return self._json
 
-    def raise_for_status(self):
+    def raise_for_status(self) -> None:
         if self.status_code >= 400:
             raise RequestException(f"Status {self.status_code}")
 
 
 def post(*args, **kwargs):
+    """Placeholder for ``requests.post``."""
+
     raise NotImplementedError("requests.post is not implemented in the stub")
 
 
 def get(*args, **kwargs):
+    """Placeholder for ``requests.get``."""
+
     raise NotImplementedError("requests.get is not implemented in the stub")
 
 
-class RequestException(Exception):
-    pass
-
 class exceptions:
+    """Namespace for exception classes to mirror ``requests.exceptions``."""
+
     RequestException = RequestException
+


### PR DESCRIPTION
## Summary
- clean up `requests` stub and add docstring

## Testing
- `python - <<'PY'
import warpcast_api
print('loaded warpcast_api')
PY`