### PR TITLE
Fix tests

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -2,6 +2,9 @@ import asyncio
 import json
 
 import main
+from fastapi.testclient import TestClient
+
+client = TestClient(main.app)
 
 # Helper request object for mcp_message
 class FakeRequest:
@@ -114,18 +117,16 @@ def test_mcp_multiple_streams():
         assert not main.mcp_queues
     asyncio.run(run_test())
 
-    response = client.post("/unfollow-channel", json={"channel_id": "xyz"})
-    assert response.status_code == 200
-    assert response.json() == {"status": "success", "channel": "xyz"}
-
 
 def test_handshake_removed():
     response = client.post("/handshake", json={})
     assert response.status_code == 404
 
-    def test_mcp_stream_invalid_origin():
+
+def test_mcp_stream_invalid_origin():
     response = client.get("/mcp", headers={"Origin": "http://evil.com"})
     assert response.status_code == 403
+
 
 def test_mcp_stream_missing_origin():
     response = client.get("/mcp")


### PR DESCRIPTION
## Summary
- create a `TestClient` for the `FastAPI` app
- clean up `tests/test_routes.py` by removing stray lines and fixing indentation

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*