### PR TITLE
Add origin check for MCP POST

### DIFF
--- a/main.py
+++ b/main.py
@@ -130,6 +130,9 @@ async def mcp_stream(request: Request):
 @app.post("/mcp")
 async def mcp_message(request: Request):
     """Handle JSON-RPC messages sent by the client."""
+    origin = request.headers.get("origin")
+    if not origin or not _origin_allowed(origin):
+        raise HTTPException(status_code=403)
     message = await request.json()
 
     if message.get("method") == "initialize":

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -158,3 +158,13 @@ def test_mcp_stream_initial_event():
         assert not main.mcp_queues
 
     asyncio.run(run_test())
+
+
+def test_mcp_post_invalid_origin():
+    response = client.post("/mcp", json={}, headers={"Origin": "http://evil.com"})
+    assert response.status_code == 403
+
+
+def test_mcp_post_missing_origin():
+    response = client.post("/mcp", json={"method": "initialize"})
+    assert response.status_code == 403


### PR DESCRIPTION
## Summary
- check the `Origin` header in `mcp_message`
- ensure POST `/mcp` without allowed origin returns 403
- cover invalid or missing origin on POST `/mcp` in tests

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*