### PR TITLE
Improve SSE origin handling and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,12 @@ JSON-RPC message. The response on the event stream includes
 
 ### Initialization example
 
-In one terminal start listening for events:
+In one terminal start listening for events (the request **must** include an
+`Origin` header matching `localhost` or a value listed in `ALLOWED_ORIGINS`):
 
 ```bash
-curl -N http://localhost:8000/mcp
+curl -N http://localhost:8000/mcp \
+     -H "Origin: http://localhost"
 ```
 
 In another terminal send the `initialize` message:


### PR DESCRIPTION
## Summary
- add defaults for `ALLOWED_ORIGINS`
- improve `_origin_allowed` logic and provide verbose logging
- output debug info for `/mcp` SSE and JSON-RPC messages

## Testing
- `python -m py_compile main.py tests/test_routes.py warpcast_api.py`
- `pytest -q` *(fails: command not found)*