### PR TITLE
Refresh Warpcast API token

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -168,3 +168,15 @@ def test_mcp_post_invalid_origin():
 def test_mcp_post_missing_origin():
     response = client.post("/mcp", json={"method": "initialize"})
     assert response.status_code == 403
+
+
+def test_auth_helpers_environment(monkeypatch):
+    monkeypatch.delenv("WARPCAST_API_TOKEN", raising=False)
+    import importlib
+    import warpcast_api
+    importlib.reload(warpcast_api)
+    assert not warpcast_api.has_token()
+    assert warpcast_api._auth_headers() == {}
+    monkeypatch.setenv("WARPCAST_API_TOKEN", "secret")
+    assert warpcast_api.has_token()
+    assert warpcast_api._auth_headers() == {"Authorization": "Bearer secret"}

--- a/warpcast_api.py
+++ b/warpcast_api.py
@@ -5,7 +5,6 @@ import logging
 import requests
 
 API_BASE_URL = "https://api.warpcast.com/v2"
-API_TOKEN = os.getenv("WARPCAST_API_TOKEN")
 PROPAGATE_EXCEPTIONS = os.getenv("PROPAGATE_EXCEPTIONS") is not None
 
 logger = logging.getLogger(__name__)
@@ -13,13 +12,14 @@ logger = logging.getLogger(__name__)
 
 def has_token() -> bool:
     """Return True if the API token is configured."""
-    return bool(API_TOKEN)
+    return bool(os.getenv("WARPCAST_API_TOKEN"))
 
 
 def _auth_headers() -> Dict[str, str]:
-    if not API_TOKEN:
+    token = os.getenv("WARPCAST_API_TOKEN")
+    if not token:
         return {}
-    return {"Authorization": f"Bearer {API_TOKEN}"}
+    return {"Authorization": f"Bearer {token}"}
 
 
 def post_cast(text: str) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- load `WARPCAST_API_TOKEN` from the environment on each call
- test that helper functions react to env changes

## Testing
- `make test` *(fails: pytest not found)*