### PR TITLE
Convert API to async httpx

### DIFF
--- a/httpx_stub.py
+++ b/httpx_stub.py
@@ -1,0 +1,23 @@
+"""Minimal stub of the ``httpx`` module used for testing.
+
+This provides the ``AsyncClient`` class and ``HTTPError`` exception so that
+modules importing ``httpx`` can be loaded without the real dependency.
+All HTTP methods simply raise ``NotImplementedError``.
+"""
+
+class HTTPError(Exception):
+    """Base HTTPX error class."""
+
+
+class AsyncClient:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def get(self, *args, **kwargs):
+        raise NotImplementedError("AsyncClient.get is not implemented in the stub")
+
+    async def post(self, *args, **kwargs):
+        raise NotImplementedError("AsyncClient.post is not implemented in the stub")

--- a/main.py
+++ b/main.py
@@ -190,63 +190,63 @@ async def mcp_message(request: Request):
     
 
 @app.post("/post-cast")
-def post_cast(req: CastRequest):
+async def post_cast(req: CastRequest):
     ensure_token()
-    result = warpcast_api.post_cast(req.text)
+    result = await warpcast_api.post_cast(req.text)
     if result.get("status") == "error":
         raise HTTPException(status_code=400, detail=result["message"])
     return result
 
 
 @app.get("/user-casts/{username}")
-def user_casts(username: str, limit: int = 20):
+async def user_casts(username: str, limit: int = 20):
     ensure_token()
-    return warpcast_api.get_user_casts(username, limit)
+    return await warpcast_api.get_user_casts(username, limit)
 
 
 @app.get("/search-casts")
-def search_casts(q: str, limit: int = 20):
+async def search_casts(q: str, limit: int = 20):
     ensure_token()
-    return warpcast_api.search_casts(q, limit)
+    return await warpcast_api.search_casts(q, limit)
 
 
 @app.get("/trending-casts")
-def trending_casts(limit: int = 20):
+async def trending_casts(limit: int = 20):
     ensure_token()
-    return warpcast_api.get_trending_casts(limit)
+    return await warpcast_api.get_trending_casts(limit)
 
 
 @app.get("/channels")
-def all_channels():
+async def all_channels():
     ensure_token()
-    return warpcast_api.get_all_channels()
+    return await warpcast_api.get_all_channels()
 
 
 @app.get("/channels/{channel_id}")
-def get_channel(channel_id: str):
+async def get_channel(channel_id: str):
     ensure_token()
-    return warpcast_api.get_channel(channel_id)
+    return await warpcast_api.get_channel(channel_id)
 
 
 @app.get("/channels/{channel_id}/casts")
-def channel_casts(channel_id: str, limit: int = 20):
+async def channel_casts(channel_id: str, limit: int = 20):
     ensure_token()
-    return warpcast_api.get_channel_casts(channel_id, limit)
+    return await warpcast_api.get_channel_casts(channel_id, limit)
 
 
 @app.post("/follow-channel")
-def follow_channel(req: ChannelRequest):
+async def follow_channel(req: ChannelRequest):
     ensure_token()
-    result = warpcast_api.follow_channel(req.channel_id)
+    result = await warpcast_api.follow_channel(req.channel_id)
     if result.get("status") == "error":
         raise HTTPException(status_code=400, detail=result["message"])
     return result
 
 
 @app.post("/unfollow-channel")
-def unfollow_channel(req: ChannelRequest):
+async def unfollow_channel(req: ChannelRequest):
     ensure_token()
-    result = warpcast_api.unfollow_channel(req.channel_id)
+    result = await warpcast_api.unfollow_channel(req.channel_id)
     if result.get("status") == "error":
         raise HTTPException(status_code=400, detail=result["message"])
     return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fastapi[testclient]
 uvicorn
-requests
+httpx
 pytest

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -2,9 +2,8 @@ import asyncio
 import json
 import sys
 
-import requests_stub
-
-sys.modules["requests"] = requests_stub
+import httpx_stub
+sys.modules["httpx"] = httpx_stub
 
 import main
 from fastapi.testclient import TestClient
@@ -22,82 +21,100 @@ class FakeRequest:
 
 def test_post_cast(monkeypatch):
     monkeypatch.setattr(main, "ensure_token", lambda: None)
-    def mock_post_cast(text):
+
+    async def mock_post_cast(text):
         return {"status": "success", "text": text}
+
     monkeypatch.setattr(main.warpcast_api, "post_cast", mock_post_cast)
-    result = main.post_cast(main.CastRequest(text="hello"))
+    result = asyncio.run(main.post_cast(main.CastRequest(text="hello")))
     assert result == {"status": "success", "text": "hello"}
 
 
 def test_user_casts(monkeypatch):
     monkeypatch.setattr(main, "ensure_token", lambda: None)
-    def mock_user_casts(username, limit=20):
+
+    async def mock_user_casts(username, limit=20):
         return {"casts": [f"{username}-{limit}"]}
+
     monkeypatch.setattr(main.warpcast_api, "get_user_casts", mock_user_casts)
-    result = main.user_casts("alice", limit=5)
+    result = asyncio.run(main.user_casts("alice", limit=5))
     assert result == {"casts": ["alice-5"]}
 
 
 def test_search_casts(monkeypatch):
     monkeypatch.setattr(main, "ensure_token", lambda: None)
-    def mock_search_casts(q, limit=20):
+
+    async def mock_search_casts(q, limit=20):
         return {"results": [q, limit]}
+
     monkeypatch.setattr(main.warpcast_api, "search_casts", mock_search_casts)
-    result = main.search_casts("test", limit=3)
+    result = asyncio.run(main.search_casts("test", limit=3))
     assert result == {"results": ["test", 3]}
 
 
 def test_trending_casts(monkeypatch):
     monkeypatch.setattr(main, "ensure_token", lambda: None)
-    def mock_trending_casts(limit=20):
+
+    async def mock_trending_casts(limit=20):
         return {"trending": limit}
+
     monkeypatch.setattr(main.warpcast_api, "get_trending_casts", mock_trending_casts)
-    result = main.trending_casts(limit=4)
+    result = asyncio.run(main.trending_casts(limit=4))
     assert result == {"trending": 4}
 
 
 def test_all_channels(monkeypatch):
     monkeypatch.setattr(main, "ensure_token", lambda: None)
-    def mock_all_channels():
+
+    async def mock_all_channels():
         return {"channels": []}
+
     monkeypatch.setattr(main.warpcast_api, "get_all_channels", mock_all_channels)
-    result = main.all_channels()
+    result = asyncio.run(main.all_channels())
     assert result == {"channels": []}
 
 
 def test_get_channel(monkeypatch):
     monkeypatch.setattr(main, "ensure_token", lambda: None)
-    def mock_get_channel(channel_id):
+
+    async def mock_get_channel(channel_id):
         return {"channel": channel_id}
+
     monkeypatch.setattr(main.warpcast_api, "get_channel", mock_get_channel)
-    result = main.get_channel("123")
+    result = asyncio.run(main.get_channel("123"))
     assert result == {"channel": "123"}
 
 
 def test_channel_casts(monkeypatch):
     monkeypatch.setattr(main, "ensure_token", lambda: None)
-    def mock_channel_casts(channel_id, limit=20):
+
+    async def mock_channel_casts(channel_id, limit=20):
         return {"casts": [channel_id, limit]}
+
     monkeypatch.setattr(main.warpcast_api, "get_channel_casts", mock_channel_casts)
-    result = main.channel_casts("abc", limit=2)
+    result = asyncio.run(main.channel_casts("abc", limit=2))
     assert result == {"casts": ["abc", 2]}
 
 
 def test_follow_channel(monkeypatch):
     monkeypatch.setattr(main, "ensure_token", lambda: None)
-    def mock_follow_channel(channel_id):
+
+    async def mock_follow_channel(channel_id):
         return {"status": "success", "channel": channel_id}
+
     monkeypatch.setattr(main.warpcast_api, "follow_channel", mock_follow_channel)
-    result = main.follow_channel(main.ChannelRequest(channel_id="xyz"))
+    result = asyncio.run(main.follow_channel(main.ChannelRequest(channel_id="xyz")))
     assert result == {"status": "success", "channel": "xyz"}
 
 
 def test_unfollow_channel(monkeypatch):
     monkeypatch.setattr(main, "ensure_token", lambda: None)
-    def mock_unfollow_channel(channel_id):
+
+    async def mock_unfollow_channel(channel_id):
         return {"status": "success", "channel": channel_id}
+
     monkeypatch.setattr(main.warpcast_api, "unfollow_channel", mock_unfollow_channel)
-    result = main.unfollow_channel(main.ChannelRequest(channel_id="xyz"))
+    result = asyncio.run(main.unfollow_channel(main.ChannelRequest(channel_id="xyz")))
     assert result == {"status": "success", "channel": "xyz"}
 
 

--- a/warpcast_api.py
+++ b/warpcast_api.py
@@ -2,7 +2,7 @@ import os
 from typing import Any, Dict
 
 import logging
-import requests
+import httpx
 
 API_BASE_URL = "https://api.warpcast.com/v2"
 API_TOKEN = os.getenv("WARPCAST_API_TOKEN")
@@ -22,120 +22,131 @@ def _auth_headers() -> Dict[str, str]:
     return {"Authorization": f"Bearer {API_TOKEN}"}
 
 
-def post_cast(text: str) -> Dict[str, Any]:
+async def post_cast(text: str) -> Dict[str, Any]:
     """Create a new cast on Warpcast."""
     url = f"{API_BASE_URL}/casts"
     payload = {"text": text}
     try:
-        response = requests.post(url, json=payload, headers=_auth_headers(), timeout=10)
-        response.raise_for_status()
-        return response.json()
-    except requests.exceptions.RequestException:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                url, json=payload, headers=_auth_headers(), timeout=10
+            )
+            response.raise_for_status()
+            return response.json()
+    except httpx.HTTPError:
         logger.exception("Could not post cast")
         if PROPAGATE_EXCEPTIONS:
             raise
         return {"status": "error", "message": "Could not post cast"}
 
 
-def get_user_casts(username: str, limit: int = 20) -> Dict[str, Any]:
+async def get_user_casts(username: str, limit: int = 20) -> Dict[str, Any]:
     """Retrieve recent casts from a user."""
     url = f"{API_BASE_URL}/users/{username}/casts?limit={limit}"
     try:
-        response = requests.get(url, headers=_auth_headers(), timeout=10)
-        response.raise_for_status()
-        return response.json()
-    except requests.exceptions.RequestException:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, headers=_auth_headers(), timeout=10)
+            response.raise_for_status()
+            return response.json()
+    except httpx.HTTPError:
         logger.exception("Could not fetch user casts")
         if PROPAGATE_EXCEPTIONS:
             raise
         return {"status": "error", "message": "Could not fetch user casts"}
 
 
-def search_casts(query: str, limit: int = 20) -> Dict[str, Any]:
+async def search_casts(query: str, limit: int = 20) -> Dict[str, Any]:
     url = f"{API_BASE_URL}/casts/search?q={query}&limit={limit}"
     try:
-        response = requests.get(url, headers=_auth_headers(), timeout=10)
-        response.raise_for_status()
-        return response.json()
-    except requests.exceptions.RequestException:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, headers=_auth_headers(), timeout=10)
+            response.raise_for_status()
+            return response.json()
+    except httpx.HTTPError:
         logger.exception("Could not search casts")
         if PROPAGATE_EXCEPTIONS:
             raise
         return {"status": "error", "message": "Could not search casts"}
 
 
-def get_trending_casts(limit: int = 20) -> Dict[str, Any]:
+async def get_trending_casts(limit: int = 20) -> Dict[str, Any]:
     url = f"{API_BASE_URL}/casts/trending?limit={limit}"
     try:
-        response = requests.get(url, headers=_auth_headers(), timeout=10)
-        response.raise_for_status()
-        return response.json()
-    except requests.exceptions.RequestException:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, headers=_auth_headers(), timeout=10)
+            response.raise_for_status()
+            return response.json()
+    except httpx.HTTPError:
         logger.exception("Could not fetch trending casts")
         if PROPAGATE_EXCEPTIONS:
             raise
         return {"status": "error", "message": "Could not fetch trending casts"}
 
 
-def get_all_channels() -> Dict[str, Any]:
+async def get_all_channels() -> Dict[str, Any]:
     url = f"{API_BASE_URL}/channels"
     try:
-        response = requests.get(url, headers=_auth_headers(), timeout=10)
-        response.raise_for_status()
-        return response.json()
-    except requests.exceptions.RequestException:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, headers=_auth_headers(), timeout=10)
+            response.raise_for_status()
+            return response.json()
+    except httpx.HTTPError:
         logger.exception("Could not fetch channels")
         if PROPAGATE_EXCEPTIONS:
             raise
         return {"status": "error", "message": "Could not fetch channels"}
 
 
-def get_channel(channel_id: str) -> Dict[str, Any]:
+async def get_channel(channel_id: str) -> Dict[str, Any]:
     url = f"{API_BASE_URL}/channels/{channel_id}"
     try:
-        response = requests.get(url, headers=_auth_headers(), timeout=10)
-        response.raise_for_status()
-        return response.json()
-    except requests.exceptions.RequestException:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, headers=_auth_headers(), timeout=10)
+            response.raise_for_status()
+            return response.json()
+    except httpx.HTTPError:
         logger.exception("Could not fetch channel")
         if PROPAGATE_EXCEPTIONS:
             raise
         return {"status": "error", "message": "Could not fetch channel"}
 
 
-def get_channel_casts(channel_id: str, limit: int = 20) -> Dict[str, Any]:
+async def get_channel_casts(channel_id: str, limit: int = 20) -> Dict[str, Any]:
     url = f"{API_BASE_URL}/channels/{channel_id}/casts?limit={limit}"
     try:
-        response = requests.get(url, headers=_auth_headers(), timeout=10)
-        response.raise_for_status()
-        return response.json()
-    except requests.exceptions.RequestException:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, headers=_auth_headers(), timeout=10)
+            response.raise_for_status()
+            return response.json()
+    except httpx.HTTPError:
         logger.exception("Could not fetch channel casts")
         if PROPAGATE_EXCEPTIONS:
             raise
         return {"status": "error", "message": "Could not fetch channel casts"}
 
 
-def follow_channel(channel_id: str) -> Dict[str, Any]:
+async def follow_channel(channel_id: str) -> Dict[str, Any]:
     url = f"{API_BASE_URL}/channels/{channel_id}/follow"
     try:
-        response = requests.post(url, headers=_auth_headers(), timeout=10)
-        response.raise_for_status()
-        return response.json()
-    except requests.exceptions.RequestException:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(url, headers=_auth_headers(), timeout=10)
+            response.raise_for_status()
+            return response.json()
+    except httpx.HTTPError:
         logger.exception("Could not follow channel")
         if PROPAGATE_EXCEPTIONS:
             raise
         return {"status": "error", "message": "Could not follow channel"}
 
 
-def unfollow_channel(channel_id: str) -> Dict[str, Any]:
+async def unfollow_channel(channel_id: str) -> Dict[str, Any]:
     url = f"{API_BASE_URL}/channels/{channel_id}/unfollow"
     try:
-        response = requests.post(url, headers=_auth_headers(), timeout=10)
-        response.raise_for_status()
-        return response.json()
-    except requests.exceptions.RequestException:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(url, headers=_auth_headers(), timeout=10)
+            response.raise_for_status()
+            return response.json()
+    except httpx.HTTPError:
         logger.exception("Could not unfollow channel")
         if PROPAGATE_EXCEPTIONS:
             raise


### PR DESCRIPTION
## Summary
- switch HTTP layer to async `httpx.AsyncClient`
- expose async Warpcast helpers
- update FastAPI routes to be async
- adjust tests for async behaviour
- provide minimal `httpx_stub` for tests
- replace `requests` dependency with `httpx`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*
- `pip install -q pytest` *(fails: Could not find a version that satisfies the requirement pytest)*