### PR TITLE
Add tests and custom runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@
 
 # Run the unit test suite
 test:
-	pytest -q
+	python run_tests.py

--- a/main.py
+++ b/main.py
@@ -152,7 +152,10 @@ async def mcp_message(request: Request):
     if not origin or not _origin_allowed(origin):
         print("Origin not allowed", file=sys.stderr)
         raise HTTPException(status_code=403)
-    message = await request.json()
+    try:
+        message = await request.json()
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=400, detail="Invalid JSON")
     print(f"Received message: {message}", file=sys.stderr)
 
     if message.get("method") == "initialize":

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,72 @@
+import os
+import importlib
+import inspect
+import asyncio
+
+class MonkeyPatch:
+    def __init__(self):
+        self._actions = []
+
+    def setattr(self, obj, name, value):
+        orig = getattr(obj, name)
+        self._actions.append((obj, name, orig))
+        setattr(obj, name, value)
+
+    def setitem(self, mapping, key, value):
+        orig = mapping.get(key)
+        self._actions.append((mapping, key, orig, True if key in mapping else False))
+        mapping[key] = value
+
+    def undo(self):
+        for item in reversed(self._actions):
+            if len(item) == 3:
+                obj, name, orig = item
+                setattr(obj, name, orig)
+            else:
+                mapping, key, orig, existed = item
+                if existed:
+                    mapping[key] = orig
+                else:
+                    mapping.pop(key, None)
+        self._actions.clear()
+
+
+def run_func(func):
+    sig = inspect.signature(func)
+    kwargs = {}
+    mp = None
+    if 'monkeypatch' in sig.parameters:
+        mp = MonkeyPatch()
+        kwargs['monkeypatch'] = mp
+    try:
+        if inspect.iscoroutinefunction(func):
+            asyncio.run(func(**kwargs))
+        else:
+            func(**kwargs)
+        result = True
+    except Exception as e:
+        print(f"FAILED: {func.__name__}: {e}")
+        result = False
+    finally:
+        if mp:
+            mp.undo()
+    return result
+
+
+def main():
+    failed = 0
+    for filename in os.listdir('tests'):
+        if filename.startswith('test_') and filename.endswith('.py'):
+            module = importlib.import_module(f'tests.{filename[:-3]}')
+            for name, func in inspect.getmembers(module, inspect.isfunction):
+                if name.startswith('test_'):
+                    print(f'running {filename}:{name}')
+                    if not run_func(func):
+                        failed += 1
+    if failed:
+        print(f'{failed} tests failed')
+        raise SystemExit(1)
+    print('all tests passed')
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -7,14 +7,14 @@ import requests_stub
 sys.modules["requests"] = requests_stub
 
 import main
-from fastapi.testclient import TestClient
-
-client = TestClient(main.app)
 
 # Helper request object for mcp_message
 class FakeRequest:
-    def __init__(self, payload):
-        self._payload = payload
+    def __init__(self, payload=None, headers=None):
+        self._payload = payload or {}
+        if headers is None:
+            headers = {"origin": "http://localhost"}
+        self.headers = headers
 
     async def json(self):
         return self._payload
@@ -126,18 +126,31 @@ def test_mcp_multiple_streams():
 
 
 def test_handshake_removed():
-    response = client.post("/handshake", json={})
-    assert response.status_code == 404
+    assert not any(route.path == "/handshake" for route in main.app.routes)
 
 
 def test_mcp_stream_invalid_origin():
-    response = client.get("/mcp", headers={"Origin": "http://evil.com"})
-    assert response.status_code == 403
+    async def run_test():
+        try:
+            await main.mcp_stream(FakeRequest(headers={"origin": "http://evil.com"}))
+        except main.HTTPException as exc:
+            assert exc.status_code == 403
+        else:
+            assert False, "Expected HTTPException"
+
+    asyncio.run(run_test())
 
 
 def test_mcp_stream_missing_origin():
-    response = client.get("/mcp")
-    assert response.status_code == 403
+    async def run_test():
+        try:
+            await main.mcp_stream(FakeRequest(headers={}))
+        except main.HTTPException as exc:
+            assert exc.status_code == 403
+        else:
+            assert False, "Expected HTTPException"
+
+    asyncio.run(run_test())
 
 
 def test_mcp_stream_initial_event():
@@ -161,10 +174,65 @@ def test_mcp_stream_initial_event():
 
 
 def test_mcp_post_invalid_origin():
-    response = client.post("/mcp", json={}, headers={"Origin": "http://evil.com"})
-    assert response.status_code == 403
+    async def run_test():
+        try:
+            await main.mcp_message(FakeRequest({}, headers={"origin": "http://evil.com"}))
+        except main.HTTPException as exc:
+            assert exc.status_code == 403
+        else:
+            assert False, "Expected HTTPException"
+
+    asyncio.run(run_test())
 
 
 def test_mcp_post_missing_origin():
-    response = client.post("/mcp", json={"method": "initialize"})
-    assert response.status_code == 403
+    async def run_test():
+        try:
+            await main.mcp_message(FakeRequest({"method": "initialize"}, headers={}))
+        except main.HTTPException as exc:
+            assert exc.status_code == 403
+        else:
+            assert False, "Expected HTTPException"
+
+    asyncio.run(run_test())
+
+
+def test_post_cast_missing_token(monkeypatch):
+    monkeypatch.setattr(main.warpcast_api, "has_token", lambda: False)
+    try:
+        main.post_cast(main.CastRequest(text="hi"))
+    except main.HTTPException as exc:
+        assert exc.status_code == 500
+    else:
+        assert False, "Expected HTTPException"
+
+
+def test_mcp_post_unknown_method():
+    async def run_test():
+        try:
+            await main.mcp_message(FakeRequest({"method": "unknown"}))
+        except main.HTTPException as exc:
+            assert exc.status_code == 404
+        else:
+            assert False, "Expected HTTPException"
+
+    asyncio.run(run_test())
+
+
+def test_mcp_post_invalid_json():
+    class BadRequest:
+        def __init__(self):
+            self.headers = {"origin": "http://localhost"}
+
+        async def json(self):
+            raise json.JSONDecodeError("bad", "bad", 0)
+
+    async def run_test():
+        try:
+            await main.mcp_message(BadRequest())
+        except main.HTTPException as exc:
+            assert exc.status_code == 400
+        else:
+            assert False, "Expected HTTPException"
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- add a minimal pytest replacement (`run_tests.py`)
- switch Makefile to use the new runner
- improve `/mcp` JSON parsing
- rewrite route tests and add cases for missing token, unknown method and invalid JSON

## Testing
- `make test`